### PR TITLE
Fix Job.runner logging to use instance content

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -39,7 +39,7 @@ class Job:
         self.thread.start()
 
     def runner(self):
-        log("executor for self.cmd_id %r started. content:\n%s\n####" % (self.cmd_id, content))
+        log("executor for self.cmd_id %r started. content:\n%s\n####" % (self.cmd_id, self.content))
         self.sleep(1)
         self.output("this is reponse for %r -- started!\n2nd line, no newline" % self.cmd_id)
         self.sleep(1)


### PR DESCRIPTION
## Summary
- fix Job.runner to log self.content instead of undefined content

## Testing
- `python -m py_compile executor.py`


------
https://chatgpt.com/codex/tasks/task_e_6895d0b5aab88328901ddbce85a2d59f